### PR TITLE
node:setdefaults command implemented

### DIFF
--- a/Classes/CRON/CRLib/Command/NodeCommandController.php
+++ b/Classes/CRON/CRLib/Command/NodeCommandController.php
@@ -580,7 +580,7 @@ class NodeCommandController extends \TYPO3\Flow\Cli\CommandController {
 		$totalCount = $nodeQuery->getCount();
 		if (!$dryRun) $this->output->progressStart($totalCount);
 
-		foreach (new NodeIterator($nodeQuery->getQuery(),null, true) as $node) {
+		foreach (new NodeIterator($nodeQuery->getQuery(), null, false) as $node) {
 			$nodeType = $node->getNodeType();
 			foreach ($nodeType->getDefaultValuesForProperties() as $propertyName => $defaultValue) {
 				if ($force === $propertyName || !$node->hasProperty($propertyName)) {


### PR DESCRIPTION
```
[www@58793514868a : ~/typo3-app]$ ./flow help node:setdefaults

Set all default values for the specified node type

COMMAND:
  cron.crlib:node:setdefaults

USAGE:
  ./flow node:setdefaults [<options>]

OPTIONS:
  --path               limit to this path only
  --type               NodeType Filter
  --dry-run            
  --force              property name DANGER ZONE: this option will basically
                       overwrite(!) existing values with the defaults for the
                       selected property

DESCRIPTION:
  This is an alternative method to typo3cr:node:repair command, being more efficient
  and scalable.
```
