### PR TITLE
Do not set order by default globally (bugfix on delete)

### DIFF
--- a/Classes/CRON/CRLib/Utility/NodeQuery.php
+++ b/Classes/CRON/CRLib/Utility/NodeQuery.php
@@ -63,8 +63,6 @@ class NodeQuery {
 		if ($this->initialPathConstraint) $this->addPathConstraint($this->initialPathConstraint);
 		if ($this->initialTypeConstraint) $this->addTypeConstraint($this->initialTypeConstraint);
 		if ($this->initialSearchTermConstraint) $this->addSearchTermConstraint($this->initialSearchTermConstraint);
-		// set default ordering
-		$this->setOrderBy('path', 'ASC');
 	}
 
 	/**
@@ -121,6 +119,7 @@ class NodeQuery {
 	 * @return \Doctrine\ORM\Query
 	 */
 	public function getQuery() {
+		$this->setOrderBy('path', 'ASC');
 		return $this->queryBuilder->getQuery();
 	}
 


### PR DESCRIPTION
On DELETE this orderBy results in an exception:
```
Error: Expected end of string, got 'ORDER'
```
Set it only when doing the "get".