### PR TITLE
composer.json PSR-4 compliance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"CRON\\CRLib": "Classes"
+			"CRON\\CRLib\\": "Classes"
 		}
 	}
 }


### PR DESCRIPTION
fixes psr-4 namespaces must end with a namespace separator error